### PR TITLE
[Feat] 대시 보드에서 이전 진단 결과 볼수 있도록 구현/#55

### DIFF
--- a/src/components/DiseaseAnalysisStep3/DetailsPanel.tsx
+++ b/src/components/DiseaseAnalysisStep3/DetailsPanel.tsx
@@ -341,9 +341,10 @@ const CarouselWrapper = styled.div`
   align-items: center;
 `;
 const CarouselImg = styled.img`
-  max-width: 100%;
-  max-height: 60vh;
-  object-fit: contain;
+  width: 100%;            /* 기본적으로 가로 폭을 가득 채움 */
+  height: auto;           /* 가로 기준으로 비율 유지 */
+  max-height: 80vh;       /* 세로가 너무 길면 화면 높이의 80%로 제한 */
+  object-fit: contain;    /* 이미지가 잘리지 않도록 */
   border-radius: 0.5rem;
 `;
 const NavBtns = styled.div`

--- a/src/components/DiseaseAnalysisStep3/DetailsPanel.tsx
+++ b/src/components/DiseaseAnalysisStep3/DetailsPanel.tsx
@@ -131,7 +131,7 @@ const StreamingTabContent = styled(TabContent)`
 
 `;
 
-export type TabType = 'photos' | 'summary' | 'description' | 'precautions' | 'management';
+export type TabType = 'summary' | 'description' | 'precautions' | 'management' | 'photos';
 
 interface DiseaseInfo {
   disease_name: string;
@@ -189,7 +189,6 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({
       
       <DetailsBox>
         <TabNav>
-        <TabButton $isActive={activeTab==='photos'} onClick={()=>setActiveTab('photos')}>사진</TabButton>
           <TabButton $isActive={activeTab === 'summary'} onClick={() => setActiveTab('summary')}>
             요약
           </TabButton>
@@ -202,6 +201,8 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({
           <TabButton $isActive={activeTab === 'management'} onClick={() => setActiveTab('management')}>
             관리법
           </TabButton>
+          <TabButton $isActive={activeTab==='photos'} onClick={()=>setActiveTab('photos')}>사진</TabButton>
+
         </TabNav>
 
         <TabContentContainer>

--- a/src/components/DiseaseAnalysisStep3/DetailsPanel.tsx
+++ b/src/components/DiseaseAnalysisStep3/DetailsPanel.tsx
@@ -229,10 +229,6 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({
               {analysisMetrics && (
                 <>
                   <SummaryItem>
-                    <span className="label">피부 점수</span>
-                    <span className="value">{analysisMetrics.skin_score}점</span>
-                  </SummaryItem>
-                  <SummaryItem>
                     <span className="label">심각도</span>
                     <SeverityBar>
                       <SeverityBarInner $severity={diseaseInfo.confidence} />

--- a/src/components/DiseaseAnalysisStep3/SharedStyles.ts
+++ b/src/components/DiseaseAnalysisStep3/SharedStyles.ts
@@ -171,7 +171,11 @@ export const TabButton = styled.button<{ $isActive: boolean }>`
   ${({ $isActive }) => $isActive && css` color: #157FF1; border-bottom-color: #157FF1; `}
 `;
 
-export const TabContentContainer = styled.div` padding: 1rem 2rem; flex-grow: 1; `;
+export const TabContentContainer = styled.div`
+  padding: 1rem 2rem;
+  flex-grow: 1;
+  min-height: 28rem; /* 요약 탭 기준으로 일정 높이 유지 */
+`;
 export const TabContent = styled.div`
   h3 { font-weight: 700; font-size: 1.125rem; color: #1e293b; margin: 0 0 0.75rem; }
   ul { list-style: disc; list-style-position: inside; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.5rem; color: #475569; line-height: 1.6; }

--- a/src/pages/DiagnosisDetailPage.tsx
+++ b/src/pages/DiagnosisDetailPage.tsx
@@ -72,11 +72,7 @@ const DiagnosisDetailPage: React.FC = () => {
   return (
     <ContentWrapper>
       <MainContent>
-        <ChartPanel
-          imageUrl={detail.image_base64}
-          analysisResult={{ disease_name: diseaseInfo.disease_name, confidence: diseaseInfo.confidence }}
-          metrics={analysisMetrics}
-        />
+        <ChartPanel analysisResult={{ disease_name: diseaseInfo.disease_name, confidence: diseaseInfo.confidence }} />
         <DetailsPanel
         imageUrls={detail.image_base64 ? [detail.image_base64] : []}
         diseaseInfo={diseaseInfo}

--- a/src/pages/DiagnosisDetailPage.tsx
+++ b/src/pages/DiagnosisDetailPage.tsx
@@ -56,8 +56,8 @@ const DiagnosisDetailPage: React.FC = () => {
   const streamingContent = {
     summary: detail.text_analysis.ai_opinion,
     description: detail.text_analysis.detailed_description,
-    precautions: '',
-    management: '',
+    precautions: detail.text_analysis.precautions,
+    management: detail.text_analysis.management,
   };
 
   const analysisMetrics = {

--- a/src/pages/DiagnosisDetailPage.tsx
+++ b/src/pages/DiagnosisDetailPage.tsx
@@ -5,6 +5,9 @@ import type { DiagnosisDetail } from '../services/types';
 import DetailsPanel from '../components/DiseaseAnalysisStep3/DetailsPanel';
 import type { TabType } from '../components/DiseaseAnalysisStep3/DetailsPanel';
 import styled from 'styled-components';
+import { ContentWrapper } from '../components/Layout';
+import ChartPanel from '../components/DiseaseAnalysisStep3/ChartPanel';
+import { MainContent } from '../components/DiseaseAnalysisStep3/SharedStyles';
 
 // 진단 상세 페이지 컨테이너
 const PageWrapper = styled.div`
@@ -67,8 +70,14 @@ const DiagnosisDetailPage: React.FC = () => {
   };
 
   return (
-    <PageWrapper>
-      <DetailsPanel
+    <ContentWrapper>
+      <MainContent>
+        <ChartPanel
+          imageUrl={detail.image_base64}
+          analysisResult={{ disease_name: diseaseInfo.disease_name, confidence: diseaseInfo.confidence }}
+          metrics={analysisMetrics}
+        />
+        <DetailsPanel
         imageUrls={detail.image_base64 ? [detail.image_base64] : []}
         diseaseInfo={diseaseInfo}
         streamingContent={streamingContent}
@@ -82,7 +91,8 @@ const DiagnosisDetailPage: React.FC = () => {
         onSave={() => {}}
         onRestart={() => navigate('/disease-analysis-step1')}
       />
-    </PageWrapper>
+      </MainContent>
+    </ContentWrapper>
   );
 };
 


### PR DESCRIPTION
### PR Type

<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [ ] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

---

### Summary
<img width="1333" height="686" alt="image" src="https://github.com/user-attachments/assets/6425d917-e74a-4630-a398-2857008213fc" />
사진탭 맨 오른쪽 
사진 크기 수정
일부 탭 랜더링 오류 수정

---

### Description

---

### Issue Number
